### PR TITLE
OnAllPluginsLoaded into OnConfigsExecuted

### DIFF
--- a/scripting/command_to_server.sp
+++ b/scripting/command_to_server.sp
@@ -55,7 +55,7 @@ public int OnCtsSettingsChanged(Handle convar, const char[] oldValue, const char
     }
 }
 
-public void OnAllPluginsLoaded() 
+public void OnConfigsExecuted() 
 {
     gBot = new DiscordBot(g_sBotToken);
     


### PR DESCRIPTION
Sometimes the bot won't read commands, which makes sense because OnAllPluginsLoaded can call before OnConfigsExecuted.

You don't have to let the discord load to use its natives. If you do, use libraries.